### PR TITLE
Remove explicit version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "emojione/assets",
-  "version": "3.1.0",
   "type": "library",
   "description": "Emojis in png format brought to you by EmojiOne. EmojiOne is a complete set of emojis designed for the web.",
   "keywords": [


### PR DESCRIPTION
An explicit version has only drawbacks and no benefits when the package is managed in a VCS repository:

- for branch versions, composer ignores the explicit version anyway and uses only the branch name to build the version
- for tag versions, composer builds a version based on the tag name. If there is an explicit version, it then checks if it matches the guessed one, and skip the tag if not, as being a broken release

So putting an explicit version can only lead to broken releases. Using an explicit version in the composer.json is useful only when using more exotic package management systems.