### PR TITLE
Add Travis job to build fonts automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: generic
+
+sudo: required
+
+env:
+  global:
+    - FONTS_DIR="$TRAVIS_BUILD_DIR/fonts"
+
+services:
+  - docker
+
+install:
+  - docker pull maximbaz/emojione-fonts-build
+  - mkdir "$FONTS_DIR"
+
+script:
+  - docker run --rm -v "$FONTS_DIR":/fonts -v "$TRAVIS_BUILD_DIR":/assets maximbaz/emojione-fonts-build
+
+deploy:
+  on:
+    tags: true
+  skip_cleanup: true
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  file:
+    - "$FONTS_DIR/emojione-android.ttf"


### PR DESCRIPTION
This creates a Travis job to solve #25.

@kevinranks it is needed to put job in this repo, because changes to assets should trigger building a new font. Travis will build font on every commit (so that you get early notification if build breaks for some reason), but it will attach the font to the release only when you push a git tag.

Hypothetically it is possible to choose a different location for uploading fonts (see section [Deployments and Uploads](https://docs.travis-ci.com/user/deployment/releases/) on the left side), but it's not immediately obvious how to configure the job to attach to fonts to another repo.

Since attaching fonts to the releases in _this_ repo is simple, maybe let's keep it like that, and you can then manually copy the font and also upload to another location?

------

What the owner of this repo/org should do _after this is merged_:

- On Github:
  - Go [here](https://github.com/settings/tokens), generate a new token and assign it "public_repo" scope. Make sure to copy it!

![image](https://user-images.githubusercontent.com/1177900/29072160-e53d4af0-7c46-11e7-9ced-08c3edff7020.png)

- On Travis:
  - Register on https://travis-ci.org
  - Sync account and enable building of emojione/emojione-assets:

![image](https://user-images.githubusercontent.com/1177900/29072055-7b381338-7c46-11e7-93b3-2b6c9b291880.png)

  - Go to project settings:

![image](https://user-images.githubusercontent.com/1177900/29072096-aad60b90-7c46-11e7-883f-f836e0194ecd.png)

  - In the section "Environment variables" create a new variable with name "GITHUB_OAUTH_TOKEN" and value of the token that you generated on the first step.

Then try to commit something to this repo, and see that the build is triggered and succeeded. Next time you will push a tag it will also trigger the job, but then additionally attach "emojione-android.ttf" to the release.