### PR TITLE
Travis: include alternative font in releases as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ deploy:
   api_key: $GITHUB_OAUTH_TOKEN
   file:
     - "$FONTS_DIR/emojione-android.ttf"
+    - "$FONTS_DIR/emojione-android-alt.ttf"


### PR DESCRIPTION
Travis is now building the alternative font for Linux & Android that includes water gun. This PR will just make sure to attach the alternative font as well when it is built.

Also, I updated the build system, part of the change is that font family is now "EmojiOne" instead of "Noto Color Emoji" — previously I was under assumption that this is needed for the font to work correctly on Android, but apparently [this is not the case](https://github.com/mxalbert1996/emojione-android/commit/855608437a04f99c3c4d0838b9a4b74ae0449953#r30397058).

This will solve issues like https://github.com/emojione/emojione/issues/558 and https://github.com/NixOS/nixpkgs/issues/38413.

Because this is a breaking change, I would ask you to make a new release instead of updating the `4.0` one, so that there is a period of time where both ttf files are available, for people to adjust their configs from old font (named "Noto Color Emoji") to the new font (named "EmojiOne"). Also, this will let us see if Travis is recovered or is still broken 🙂 

So, this is what I will ask you to do:

1. Merge this PR
2. Make a new release (name doesn't matter, call it `4.0.1` or something).
3. Wait 15 minutes, let's see if Travis automatically attaches 2 fonts to it.
4. If no, just attach the fonts yourself, here they are: [emojione.zip](https://github.com/emojione/emojione-assets/files/2364497/emojione.zip)
5. Open champagne 🍾 , and ping me so that I update the distribution for Arch Linux users 😉 

/cc @caseyahenson 

Fixes #35
Fixes https://github.com/emojione/emojione/issues/558